### PR TITLE
fix: preserve daily feed state on navigation

### DIFF
--- a/src/app/daily/[id]/loading.tsx
+++ b/src/app/daily/[id]/loading.tsx
@@ -1,0 +1,17 @@
+import styles from '##/app/daily/page.module.css';
+
+export default function DailyDetailLoading() {
+  return (
+    <div className="page">
+      <section className={`${styles.timelineWide} ${styles.timelineSplitMode}`} aria-label="正在加载笔记">
+        <div className={styles.detailLoading}>
+          <div className={styles.detailLoadingMeta} />
+          <div className={styles.detailLoadingTitle} />
+          <div className={styles.detailLoadingLine} />
+          <div className={styles.detailLoadingLine} />
+          <div className={`${styles.detailLoadingLine} ${styles.detailLoadingLineShort}`} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/daily/page.module.css
+++ b/src/app/daily/page.module.css
@@ -431,6 +431,41 @@
   animation: detail-content-enter 180ms ease both;
 }
 
+.detailLoading {
+  width: min(100%, 720px);
+  margin: 0 auto;
+  padding-top: 96px;
+}
+
+.detailLoadingMeta,
+.detailLoadingTitle,
+.detailLoadingLine {
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--ui-color-text) 10%, transparent);
+  animation: loading-pulse 1.2s ease-in-out infinite;
+}
+
+.detailLoadingMeta {
+  width: 132px;
+  height: 14px;
+  margin-bottom: 28px;
+}
+
+.detailLoadingTitle {
+  width: min(82%, 560px);
+  height: 54px;
+  margin-bottom: 44px;
+}
+
+.detailLoadingLine {
+  height: 15px;
+  margin-bottom: 16px;
+}
+
+.detailLoadingLineShort {
+  width: 64%;
+}
+
 .detailHeader {
   margin-bottom: 56px;
 }
@@ -465,6 +500,17 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes loading-pulse {
+  0%,
+  100% {
+    opacity: 0.46;
+  }
+
+  50% {
+    opacity: 0.9;
   }
 }
 
@@ -576,6 +622,10 @@
     padding-bottom: 0;
     border-left: 0;
     animation: detail-content-enter 180ms ease both;
+  }
+
+  .detailLoading {
+    padding-top: 72px;
   }
 
   .detailTitle {

--- a/src/components/daily/daily-detail-layout.tsx
+++ b/src/components/daily/daily-detail-layout.tsx
@@ -6,22 +6,31 @@ import {
   ChevronRightIcon,
   XIcon,
 } from '@deweyou-design/react-icons';
-import { useEffect, useState, type MouseEvent, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react';
 import styles from '##/app/daily/page.module.css';
 
 const FEED_PANEL_ID = 'daily-feed-panel';
 const FEED_COLLAPSED_KEY = 'daily-detail-feed-collapsed';
+const DAILY_ENTRY_LINK_SELECTOR = '[data-daily-entry-link="true"]';
 
 export function DailyDetailLayout({
   detail,
   feed,
+  navigationKey,
 }: {
   detail: ReactNode;
   feed: ReactNode;
+  navigationKey: string;
 }) {
+  const detailPaneRef = useRef<HTMLElement>(null);
   const [isFeedCollapsed, setIsFeedCollapsed] = useState(false);
   const [isFeedDrawerOpen, setIsFeedDrawerOpen] = useState(false);
   const [hasLoadedFeedPreference, setHasLoadedFeedPreference] = useState(false);
+
+  useLayoutEffect(() => {
+    detailPaneRef.current?.scrollTo(0, 0);
+    window.scrollTo(0, 0);
+  }, [navigationKey]);
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
@@ -55,8 +64,8 @@ export function DailyDetailLayout({
     const target = event.target;
     if (!(target instanceof Element)) return;
 
-    const feedLink = target.closest(`.${styles.feedPane} a`);
-    if (feedLink) {
+    const entryLink = target.closest(DAILY_ENTRY_LINK_SELECTOR);
+    if (entryLink) {
       setIsFeedDrawerOpen(false);
     }
   }
@@ -83,7 +92,7 @@ export function DailyDetailLayout({
         {feed}
       </div>
 
-      <aside className={styles.detailPane} aria-label="笔记详情">
+      <aside ref={detailPaneRef} className={styles.detailPane} aria-label="笔记详情">
         {detail}
       </aside>
 

--- a/src/components/daily/daily-experience.tsx
+++ b/src/components/daily/daily-experience.tsx
@@ -26,6 +26,7 @@ export function DailyExperience({
   const initialLastYear = initialBatch.entries.at(-1)?.date.slice(0, 4) ?? null;
   const activeTagQuery = activeTag ? `?tag=${encodeURIComponent(activeTag)}` : '';
   const filterBaseHref = activeId ? `/daily/${activeId}` : '/daily';
+  const navigationKey = `${activeId ?? 'index'}:${activeTag ?? 'all'}`;
   const filterContent = (
     <nav className={styles.tagFilters} aria-label="笔记标签筛选">
       <Link
@@ -69,7 +70,7 @@ export function DailyExperience({
 
   if (selectedEntry) {
     const feed = (
-      <DailyFeedPane activeTag={activeTag} id={FEED_PANEL_ID}>
+      <DailyFeedPane id={FEED_PANEL_ID} resetKey={navigationKey}>
         <header className={styles.feedHero}>{heroContent}</header>
         <DailyServerFeed
           activeId={activeId}
@@ -92,6 +93,7 @@ export function DailyExperience({
           <DailyDetailLayout
             detail={<DailyDetail closeHref={`/daily${activeTagQuery}`} entry={selectedEntry} />}
             feed={feed}
+            navigationKey={navigationKey}
           />
         </section>
       </div>
@@ -111,7 +113,7 @@ export function DailyExperience({
           </p>
         ) : (
           <div className={styles.experienceFeedOnly}>
-            <DailyFeedPane activeTag={activeTag}>
+            <DailyFeedPane resetKey={navigationKey}>
               <DailyServerFeed
                 activeId={activeId}
                 activeTag={activeTag}

--- a/src/components/daily/daily-feed-pane.tsx
+++ b/src/components/daily/daily-feed-pane.tsx
@@ -1,40 +1,28 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
 import { useLayoutEffect, useRef, type ReactNode } from 'react';
 import styles from '##/app/daily/page.module.css';
 
-const DAILY_FEED_SCROLL_KEY_PREFIX = 'daily-feed-scroll-top';
-
 export function DailyFeedPane({
-  activeTag,
   children,
   id,
+  resetKey,
 }: {
-  activeTag?: string | null;
   children: ReactNode;
   id?: string;
+  resetKey: string;
 }) {
-  const pathname = usePathname();
   const paneRef = useRef<HTMLDivElement>(null);
-  const storageKey = `${DAILY_FEED_SCROLL_KEY_PREFIX}:${activeTag ?? 'all'}`;
 
   useLayoutEffect(() => {
     const pane = paneRef.current;
     if (!pane) return;
 
-    const scrollTop = Number(sessionStorage.getItem(storageKey) ?? 0);
-    pane.scrollTop = Number.isFinite(scrollTop) ? scrollTop : 0;
-  }, [pathname, storageKey]);
-
-  function handleScroll() {
-    const pane = paneRef.current;
-    if (!pane) return;
-    sessionStorage.setItem(storageKey, String(pane.scrollTop));
-  }
+    pane.scrollTop = 0;
+  }, [resetKey]);
 
   return (
-    <div id={id} ref={paneRef} className={styles.feedPane} onScroll={handleScroll}>
+    <div id={id} ref={paneRef} className={styles.feedPane}>
       {children}
     </div>
   );

--- a/src/components/daily/daily-server-feed.tsx
+++ b/src/components/daily/daily-server-feed.tsx
@@ -29,6 +29,7 @@ export function DailyServerFeed({
           href={`/daily/${entry.id}${tagQuery}`}
           scroll={false}
           className={styles.entryOverlay}
+          data-daily-entry-link="true"
           aria-label={`打开笔记：${entry.title}`}
         />
         {shouldShowYear && <div className={styles.yearLabel}>{year}</div>}

--- a/src/components/daily/virtual-timeline.tsx
+++ b/src/components/daily/virtual-timeline.tsx
@@ -80,6 +80,7 @@ export function DailyVirtualTimeline({
           href={`/daily/${entry.id}${tagQuery}`}
           scroll={false}
           className={styles.entryOverlay}
+          data-daily-entry-link="true"
           aria-label={`打开笔记：${entry.title}`}
         />
         {shouldShowYear && <div className={styles.yearLabel}>{year}</div>}

--- a/test/daily-collapsible-feed.test.mjs
+++ b/test/daily-collapsible-feed.test.mjs
@@ -10,6 +10,9 @@ test('daily detail layout exposes desktop collapse and mobile drawer contracts',
   const detailShell = readFileSync('src/components/daily/daily-detail-shell.tsx', 'utf8');
   const experience = readFileSync('src/components/daily/daily-experience.tsx', 'utf8');
   const feedPane = readFileSync('src/components/daily/daily-feed-pane.tsx', 'utf8');
+  const serverFeed = readFileSync('src/components/daily/daily-server-feed.tsx', 'utf8');
+  const virtualTimeline = readFileSync('src/components/daily/virtual-timeline.tsx', 'utf8');
+  const detailLoading = readFileSync('src/app/daily/[id]/loading.tsx', 'utf8');
   const css = readFileSync('src/app/daily/page.module.css', 'utf8');
   const navCss = readFileSync('src/components/nav.module.css', 'utf8');
 
@@ -17,6 +20,11 @@ test('daily detail layout exposes desktop collapse and mobile drawer contracts',
   assert.match(layout, /data-feed-drawer-open/);
   assert.match(layout, /daily-feed-panel/);
   assert.match(layout, /sessionStorage/);
+  assert.match(layout, /DAILY_ENTRY_LINK_SELECTOR/);
+  assert.match(layout, /target\.closest\(DAILY_ENTRY_LINK_SELECTOR\)/);
+  assert.doesNotMatch(layout, /target\.closest\(`\.\$\{styles\.feedPane\} a`\)/);
+  assert.match(layout, /detailPaneRef\.current\?\.scrollTo\(0,\s*0\)/);
+  assert.match(layout, /window\.scrollTo\(0,\s*0\)/);
   assert.match(layout, /floatingFeedToggle/);
   assert.match(layout, /desktopFloatingFeedToggle/);
   assert.match(layout, /mobileFloatingFeedToggle/);
@@ -30,7 +38,16 @@ test('daily detail layout exposes desktop collapse and mobile drawer contracts',
   assert.match(detail, /styles\.entryTypeLabel/);
   assert.doesNotMatch(detailShell, /XIcon|styles\.closeButton|aria-label="关闭详情"/);
   assert.match(experience, /DailyDetailLayout/);
+  assert.match(experience, /navigationKey/);
+  assert.match(experience, /resetKey=\{navigationKey\}/);
   assert.match(feedPane, /id\?: string/);
+  assert.match(feedPane, /resetKey: string/);
+  assert.match(feedPane, /pane\.scrollTop = 0/);
+  assert.doesNotMatch(feedPane, /sessionStorage/);
+  assert.match(serverFeed, /data-daily-entry-link="true"/);
+  assert.match(virtualTimeline, /data-daily-entry-link="true"/);
+  assert.match(detailLoading, /DailyDetailLoading/);
+  assert.match(detailLoading, /detailLoading/);
   assert.match(css, /experienceSplit\[data-feed-collapsed="true"\]/);
   assert.match(css, /experienceSplit\[data-feed-drawer-open="true"\]/);
   assert.match(css, /align-items:\s*stretch/);
@@ -50,4 +67,5 @@ test('daily detail layout exposes desktop collapse and mobile drawer contracts',
   assert.match(css, /\.floatingFeedToggle:hover,[\s\S]*\.floatingFeedToggle:focus-visible\s*{[\s\S]*opacity:\s*0\.92/);
   assert.match(css, /experienceSplit\[data-feed-collapsed="true"\]\s+\.desktopFloatingFeedToggle/);
   assert.match(css, /experienceSplit\[data-feed-drawer-open="true"\]\s+\.mobileFloatingFeedToggle\s*{[\s\S]*visibility:\s*hidden;/);
+  assert.match(css, /\.detailLoading\s*{/);
 });


### PR DESCRIPTION
## Summary
- keep the mobile daily feed drawer open when switching tag filters
- reset feed/detail/page scroll positions when changing daily notes or tags
- add a daily detail loading skeleton for faster-feeling dynamic route transitions

## Verification
- `pnpm test`
- `pnpm lint` (0 errors, existing `<img>` warnings remain)
- `pnpm build`