### PR TITLE
[codex] Fix mobile nav viewport behavior

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,12 +15,18 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100dvh;
+  min-height: var(--visual-viewport-height, 100dvh);
   user-select: none;
 }
 
 [data-logo-auto] > img,
 [data-logo-auto] > svg {
   grid-area: 1 / 1;
+}
+
+body[data-menu-open] {
+  overflow: hidden;
+  touch-action: none;
 }
 
 [data-logo-auto] .logo-auto-dark {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import { IBM_Plex_Mono } from 'next/font/google';
 import { ThemeProvider } from '##/components/theme-provider';
+import { ViewportHeightSync } from '##/components/viewport-height-sync';
 import { Nav } from '##/components/nav';
 import { Footer } from '##/components/footer';
 import { GoogleAnalytics } from '##/components/google-analytics';
@@ -57,6 +58,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body>
         <ThemeProvider>
+          <ViewportHeightSync />
           <Nav />
           <main style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>{children}</main>
           <Footer />

--- a/src/components/home/hero.module.css
+++ b/src/components/home/hero.module.css
@@ -213,11 +213,13 @@
   .hero {
     display: flex;
     width: min(100%, 640px);
-    min-height: calc(100dvh - 194px);
+    min-height: calc(100svh - 137px);
+    min-height: calc(100dvh - 137px);
+    min-height: calc(var(--visual-viewport-height, 100dvh) - 137px);
     flex-direction: column;
     justify-content: flex-start;
     margin: 0 auto;
-    padding: clamp(44px, 7dvh, 72px) clamp(28px, 8vw, 72px) clamp(52px, 9dvh, 88px);
+    padding: clamp(22px, 4dvh, 40px) clamp(28px, 8vw, 72px) clamp(32px, 6dvh, 56px);
     text-align: center;
   }
 
@@ -362,6 +364,20 @@
     min-height: 0;
     padding-top: 0;
     padding-bottom: 24px;
+    border-top: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  :global(body):has(.hero) {
+    overflow: hidden;
+  }
+
+  :global(body):has(.hero) :global(footer) {
+    background: transparent;
+    min-height: 0;
+    padding-top: 0;
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
     border-top: 0;
   }
 }

--- a/src/components/nav.module.css
+++ b/src/components/nav.module.css
@@ -94,6 +94,9 @@
   position: fixed;
   inset: 0;
   z-index: 50;
+  height: 100dvh;
+  height: var(--visual-viewport-height, 100dvh);
+  overflow: hidden;
   background: color-mix(in srgb, var(--ui-color-canvas) 92%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -111,13 +114,19 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 24px;
+  min-height: 68px;
+  padding: max(18px, env(safe-area-inset-top)) 24px 18px;
   border-bottom: 1px solid var(--ui-color-border);
+}
+
+.overlayLogo {
+  display: inline-grid;
+  transform: translateZ(0);
 }
 
 .overlayCount {
   font-family: var(--ui-font-mono);
-  font-size: 10px;
+  font-size: 9px;
   color: var(--ui-color-text-muted);
   letter-spacing: 0.16em;
 }
@@ -141,9 +150,9 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  padding: 22px 4px;
+  padding: 18px 4px;
   font-family: var(--ui-font-display);
-  font-size: 32px;
+  font-size: 28px;
   font-weight: 500;
   color: var(--ui-color-text);
   text-decoration: none;
@@ -166,20 +175,20 @@
 
 .overlayIndex {
   font-family: var(--ui-font-mono);
-  font-size: 11px;
+  font-size: 10px;
   color: var(--ui-color-text-muted);
   letter-spacing: 0.1em;
 }
 
 .overlayBottom {
-  padding: 24px 24px 36px;
+  padding: 20px 24px max(28px, calc(env(safe-area-inset-bottom) + 20px));
   display: flex;
   justify-content: center;
   border-top: 1px solid var(--ui-color-border);
 }
 
 .closeBtn {
-  width: 56px; height: 56px;
+  width: 52px; height: 52px;
   border-radius: 50%;
   border: 1px solid var(--ui-color-border-strong);
   background: var(--ui-color-surface);

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -2,9 +2,9 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@deweyou-design/react/button';
-import { Logo, LogoAnimated, LogoStaticGreenCrisp } from './logo';
+import { LogoAnimated, LogoAutoCrisp, LogoStaticGreenCrisp } from './logo';
 import { useTheme } from './theme-provider';
 import { NAV_LINKS } from '##/content/common';
 import { SearchModal } from './search/search-modal';
@@ -15,6 +15,14 @@ export function Nav() {
   const { theme, toggleTheme } = useTheme();
   const [menuOpen, setMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+
+  useEffect(() => {
+    document.body.toggleAttribute('data-menu-open', menuOpen);
+
+    return () => {
+      document.body.removeAttribute('data-menu-open');
+    };
+  }, [menuOpen]);
 
   return (
     <nav className={styles.nav}>
@@ -51,7 +59,7 @@ export function Nav() {
       {menuOpen && (
         <div className={styles.overlay} onClick={() => setMenuOpen(false)}>
           <div className={styles.overlayTop}>
-            <Logo height={16} />
+            <LogoAutoCrisp height={20} className={styles.overlayLogo} />
             <span className={styles.overlayCount}>MENU · {NAV_LINKS.length.toString().padStart(2, '0')}</span>
           </div>
           <ul className={styles.overlayList} onClick={(e) => e.stopPropagation()}>

--- a/src/components/page-scroller.tsx
+++ b/src/components/page-scroller.tsx
@@ -4,10 +4,12 @@ import { ScrollArea } from '@deweyou-design/react';
 import type { ReactNode } from 'react';
 
 export function PageScroller({ children }: { children: ReactNode }) {
+  const viewportHeight = 'var(--visual-viewport-height, 100dvh)';
+
   return (
-    <ScrollArea.Root style={{ height: '100vh' }}>
+    <ScrollArea.Root style={{ height: viewportHeight }}>
       <ScrollArea.Viewport>
-        <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: viewportHeight }}>
           {children}
         </div>
       </ScrollArea.Viewport>

--- a/src/components/viewport-height-sync.tsx
+++ b/src/components/viewport-height-sync.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const VIEWPORT_HEIGHT_VAR = '--visual-viewport-height';
+
+function setViewportHeight() {
+  const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+  document.documentElement.style.setProperty(VIEWPORT_HEIGHT_VAR, `${viewportHeight}px`);
+}
+
+export function ViewportHeightSync() {
+  useEffect(() => {
+    setViewportHeight();
+
+    const viewport = window.visualViewport;
+    viewport?.addEventListener('resize', setViewportHeight);
+    viewport?.addEventListener('scroll', setViewportHeight);
+    window.addEventListener('resize', setViewportHeight);
+    window.addEventListener('orientationchange', setViewportHeight);
+
+    return () => {
+      viewport?.removeEventListener('resize', setViewportHeight);
+      viewport?.removeEventListener('scroll', setViewportHeight);
+      window.removeEventListener('resize', setViewportHeight);
+      window.removeEventListener('orientationchange', setViewportHeight);
+      document.documentElement.style.removeProperty(VIEWPORT_HEIGHT_VAR);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- sharpen the mobile menu header logo by using the theme-aware static logo at a larger rendered size
- tighten mobile menu typography, spacing, and close affordance
- lock page scrolling while the mobile menu is open
- sync `window.visualViewport.height` into a CSS variable so Chrome soft keyboard and browser UI changes can shrink mobile layouts reliably
- apply the viewport height variable to the home hero, mobile overlay, and shared page scroller

## Validation

- `pnpm lint` passes with existing `@next/next/no-img-element` warnings
- `pnpm build` passes

## Notes

Chrome's built-in page search UI and soft keyboard remain browser-owned surfaces, but the page now responds to `visualViewport` changes instead of relying only on `100dvh`.