### PR TITLE
fix: move daily source tracking into frontmatter

### DIFF
--- a/content/daily/2026-06-08 - 价格是一种信号.md
+++ b/content/daily/2026-06-08 - 价格是一种信号.md
@@ -4,8 +4,8 @@ title: 价格是一种信号
 date: 2026-06-08
 type: daily-share
 tags: [经济学]
+source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/经济学、理财/2026-06-08 - 价格是一种信号.md"
 ---
-<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/经济学、理财/2026-06-08 - 价格是一种信号.md -->
 
 价格最重要的作用，不是告诉我们某个东西“值不值得喜欢”，而是在资源有限、信息分散的世界里，向无数人同时发出一个简短信号：这里变稀缺了，那里可能有机会。经济学里很多看似抽象的讨论，最后都绕回这个常识——价格把供给、需求、成本、风险和替代选择压缩成一个数字，让不认识彼此的人也能协调行动。
 

--- a/content/daily/2026-06-08 - 别让命名挡住开始.md
+++ b/content/daily/2026-06-08 - 别让命名挡住开始.md
@@ -4,8 +4,8 @@ title: 别让命名挡住开始
 date: 2026-06-08
 type: daily-share
 tags: [Product]
+source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/产品/2026-06-08 - 别让命名挡住开始.md"
 ---
-<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/产品/2026-06-08 - 别让命名挡住开始.md -->
 
 很多个人软件会高估“开始之前的整理”，低估“先把东西放进去”的价值。尤其是笔记、任务、AI memory 这类产品，如果第一步就让用户决定标题、项目、标签、空间、模板，产品其实是在把自己的信息架构成本转嫁给用户。
 

--- a/content/daily/2026-06-08 - 状态要先定身份.md
+++ b/content/daily/2026-06-08 - 状态要先定身份.md
@@ -4,13 +4,13 @@ title: 状态要先定身份
 date: 2026-06-08
 type: daily-share
 tags: [AI]
+source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/AI/2026-06-08 - 状态要先定身份.md"
 sources:
   - https://github.com/langchain-ai/langgraph/releases/tag/1.2.2
   - https://github.com/langchain-ai/langgraph/pull/7913
   - https://github.com/langchain-ai/langgraph/releases/tag/checkpoint%3D%3D4.1.1
   - https://github.com/langchain-ai/langgraph/pull/7892
 ---
-<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/AI/2026-06-08 - 状态要先定身份.md -->
 
 Agent 的可恢复性，第一步不是把状态存下来，而是先给每条可复用状态一个稳定身份。LangGraph 5 月底修的一个细节很典型：当消息没有 id 时，如果异步 checkpoint 线程先把 `id=None` 序列化了，后面每次 `get_state()` / resume 都可能重新生成 UUID；同一条消息在 trace、UI、RemoveMessage 里就变成了“不同对象”。
 

--- a/content/daily/2026-06-08 - 让按钮留出阅读余地.md
+++ b/content/daily/2026-06-08 - 让按钮留出阅读余地.md
@@ -4,8 +4,8 @@ title: 让按钮留出阅读余地
 date: 2026-06-08
 type: daily-share
 tags: [Design]
+source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/设计/2026-06-08 - 让按钮留出阅读余地.md"
 ---
-<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/设计/2026-06-08 - 让按钮留出阅读余地.md -->
 
 按钮的尺寸不只是“看起来够大”，它还要为两件事留余地：手指的误差，以及文字被放大后的呼吸。Material Design 在按钮规范里把样式分成 elevated、filled、tonal、outlined、text 等层级，但真正值得注意的细节，是这些样式并不是为了让按钮更花，而是让主次动作在一眼之内被分开。
 

--- a/content/daily/2026-06-10 - Agent 失败时的体验.md
+++ b/content/daily/2026-06-10 - Agent 失败时的体验.md
@@ -4,8 +4,8 @@ title: Agent 失败时的体验
 date: 2026-06-10
 type: daily-share
 tags: [Product]
+source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/产品/2026-06-10 - Agent 失败时的体验.md"
 ---
-<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/产品/2026-06-10 - Agent 失败时的体验.md -->
 
 大多数 agent-native 产品把设计精力花在了"当一切顺利时"——任务自动完成、结果超出预期、用户感到惊喜。但产品信任真正被建立或摧毁的时刻，几乎总在 agent 失败的时候。
 

--- a/content/daily/2026-06-10 - Agent间通信要结构化信号.md
+++ b/content/daily/2026-06-10 - Agent间通信要结构化信号.md
@@ -5,9 +5,9 @@ date: 2026-06-10
 type: daily-share
 tags: [AI]
 source: "https://github.com/mastra-ai/mastra/releases; https://github.com/mastra-ai/mastra/pull/17240"
+source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/AI/2026-06-10 - Agent间通信要结构化信号.md"
 topic: Agent间通信要结构化信号
 ---
-<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/AI/2026-06-10 - Agent间通信要结构化信号.md -->
 
 Agent 之间的通信正在从"互相聊天"转向结构化信号。这不是语法偏好问题，而是可扩展性问题——当 3 个 Agent 用自然语言互相 @mention 时还能凑合，但 30 个 Agent 需要协调任务、传递状态变更、触发告警时，靠 LLM 读聊天记录来做决策就开始出错了。
 

--- a/content/daily/2026-06-10 - 当你脱口说出我没办法的时候.md
+++ b/content/daily/2026-06-10 - 当你脱口说出我没办法的时候.md
@@ -4,8 +4,8 @@ title: 当你脱口说出我没办法的时候
 date: 2026-06-10
 type: daily-share
 tags: [哲学]
+source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/哲学、心理学、社会学/2026-06-10 - 当你脱口说出我没办法的时候.md"
 ---
-<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/哲学、心理学、社会学/2026-06-10 - 当你脱口说出我没办法的时候.md -->
 
 当你脱口说出"我没办法"的时候，你可能正在行使你最根本的自由——假装自己没有选择。
 

--- a/docs/daily-system.md
+++ b/docs/daily-system.md
@@ -44,7 +44,8 @@ daily 页面渲染时会通过 [`src/components/markdown-content.tsx`](../src/co
 
 - 从 Obsidian 同步 daily 时，先以最新 `origin/main` 为基线比较新增，不要拿过期 worktree 或其他本地副本当基准
 - Obsidian 源文件可能缺少站点所需的 `id`、`title`、`date`；复制后要先补齐 frontmatter，再跑 build
+- 复制自 Obsidian 的真实源路径应写进私有 frontmatter 字段 `source_path`；它只用于同步追溯，不属于页面内容 schema，也不会出现在正文渲染里
 - 新增 daily 或 daily 正文字符集变化后，要运行 [`scripts/subset-fonts.sh`](../scripts/subset-fonts.sh)
 
 ---
-*Last updated: 2026-06-09 | Reason: document daily tag navigation and detail loading interaction invariants*
+*Last updated: 2026-06-10 | Reason: move daily sync source tracking into private frontmatter*

--- a/docs/nav-and-layout.md
+++ b/docs/nav-and-layout.md
@@ -32,6 +32,12 @@ To re-enable, uncomment these lines. The pages (`src/app/portfolio/page.tsx`, `s
 
 Body is `display: flex; flex-direction: column; min-height: 100dvh`. Nav is sticky; Footer scrolls (not fixed). Pages that need the full-bleed layout should use `.page` class.
 
+### Font Loading Constraint
+
+`src/app/layout.tsx` uses `next/font/local` for both serif content fonts and the mono UI variable. The mono slot (`--font-ibm-plex-mono`) is currently backed by local [`src/app/fonts/GeistMonoLatin-Regular.woff2`](../src/app/fonts/GeistMonoLatin-Regular.woff2) rather than `next/font/google`.
+
+Treat this as a build reliability invariant: in restricted or offline environments, `next/font/google` can fail the production build while fetching Google Fonts at build time. If you change the root mono font again, keep it self-hosted or verify that every build environment has outbound access.
+
 ## Logo Rendering
 
 Desktop navigation keeps the animated SVG asset (`/logo-animated.svg`) unchanged. Mobile navigation and footer use crisp inline SVG variants from `src/components/logo.tsx`; the static logo assets use mask-based SVGs that can look blurry at small mobile sizes.
@@ -55,4 +61,4 @@ Static content data lives in `src/content/`:
 
 `src/app/globals.css` overrides design system CSS variables with Next.js `localFont` variables, and sets global body/article styles.
 
-*Last updated: 2026-06-08 | Reason: mobile logo rendering note added after small-size mask SVG blur fix*
+*Last updated: 2026-06-10 | Reason: document root layout local-font requirement for build reliability*

--- a/docs/search-system.md
+++ b/docs/search-system.md
@@ -25,9 +25,11 @@ Current sources:
 - `content/posts/*.mdx` through `src/lib/posts.ts`
 - `content/daily/*.{md,mdx}` through `src/lib/daily.ts`
 
-Daily entries may include Obsidian sync comments such as
-`<!-- source: ... -->`; `src/lib/daily.ts` strips those before rendering or
-indexing so local filesystem paths never appear on the site.
+Daily entries may include a private frontmatter field such as `source_path` for
+Obsidian sync provenance. That field is not part of the search document mapping,
+and legacy `<!-- source: ... -->` comments are still stripped by
+`src/lib/daily.ts` before rendering or indexing so local filesystem paths never
+appear on the site.
 
 ## Build Behavior
 

--- a/src/lib/daily.ts
+++ b/src/lib/daily.ts
@@ -16,6 +16,7 @@ export interface DailyEntry {
   date: string;
   type: DailyEntryType;
   tags: string[];
+  sourcePath?: string;
   content: string;
 }
 
@@ -66,6 +67,12 @@ function normalizeId(value: unknown, file: string): string {
   throw new Error(`Daily entry ${file} must include id using letters, numbers, hyphens, or underscores`);
 }
 
+function normalizeOptionalSourcePath(value: unknown, file: string): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'string' && value.trim() !== '') return value;
+  throw new Error(`Daily entry ${file} source_path must be a non-empty string when provided`);
+}
+
 function cleanDailyContent(content: string): string {
   return content.replace(/^\s*<!--\s*source:\s*.*?-->\s*\n?/gim, '').trimStart();
 }
@@ -90,6 +97,7 @@ function readEntry(file: string): DailyEntry {
     date,
     type: normalizeType(data.type, file),
     tags: normalizeTags(data.tags, file),
+    sourcePath: normalizeOptionalSourcePath(data.source_path, file),
     content: cleanDailyContent(content),
   };
 }

--- a/test/daily.test.mjs
+++ b/test/daily.test.mjs
@@ -57,7 +57,7 @@ test('daily reader ignores non-entry markdown files', async () => {
   }
 });
 
-test('daily reader removes source comments from rendered content', async () => {
+test('daily reader keeps source_path in frontmatter without leaking it into rendered content', async () => {
   const originalCwd = process.cwd();
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'daily-source-'));
   fs.mkdirSync(path.join(tmp, 'content', 'daily'), { recursive: true });
@@ -70,9 +70,8 @@ test('daily reader removes source comments from rendered content', async () => {
       'date: 2026-06-05',
       'type: daily-share',
       'tags: [设计]',
+      'source_path: "/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/设计/2026-06-05 - 把复杂留到第二步.md"',
       '---',
-      '<!-- source: /Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/设计/2026-06-05 - 把复杂留到第二步.md -->',
-      '',
       '先让用户看到主要路径。',
     ].join('\n'),
   );
@@ -82,9 +81,43 @@ test('daily reader removes source comments from rendered content', async () => {
     const daily = await import(`../src/lib/daily.ts?daily-source-${Date.now()}`);
     const [entry] = daily.getAllDailyEntries();
 
+    assert.equal(entry.sourcePath, '/Users/deweyou/Library/Mobile Documents/iCloud~md~obsidian/Documents/Dewey Ou/学习/每日分享/设计/2026-06-05 - 把复杂留到第二步.md');
+    assert.equal(entry.content.trim(), '先让用户看到主要路径。');
+  } finally {
+    process.chdir(originalCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('daily reader still strips legacy source comments from rendered content', async () => {
+  const originalCwd = process.cwd();
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'daily-source-comment-'));
+  fs.mkdirSync(path.join(tmp, 'content', 'daily'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmp, 'content', 'daily', '2026-06-05 - 旧同步格式兼容.md'),
+    [
+      '---',
+      'id: daily-share-2026-06-05-legacy-source-comment',
+      'title: 旧同步格式兼容',
+      'date: 2026-06-05',
+      'type: daily-share',
+      'tags: [工程]',
+      '---',
+      '<!-- source: /Users/example/legacy.md -->',
+      '',
+      '兼容旧格式，避免注释被正文渲染出来。',
+    ].join('\n'),
+  );
+
+  try {
+    process.chdir(tmp);
+    const daily = await import(`../src/lib/daily.ts?daily-source-comment-${Date.now()}`);
+    const [entry] = daily.getAllDailyEntries();
+
+    assert.equal(entry.sourcePath, undefined);
     assert.ok(!entry.content.includes('source:'));
     assert.ok(!entry.content.includes('<!--'));
-    assert.equal(entry.content.trim(), '先让用户看到主要路径。');
+    assert.equal(entry.content.trim(), '兼容旧格式，避免注释被正文渲染出来。');
   } finally {
     process.chdir(originalCwd);
     fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- move Obsidian source tracking from HTML comments into private `source_path` frontmatter
- keep `src/lib/daily.ts` compatible with legacy `<!-- source: ... -->` comments
- migrate existing daily entries and update repository docs

## Verification
- `corepack pnpm test`
- `corepack pnpm build`
- `corepack pnpm lint`