### PR TITLE
fix: align mobile ui rhythm

### DIFF
--- a/src/app/daily/page.module.css
+++ b/src/app/daily/page.module.css
@@ -59,7 +59,6 @@
 .tagFilter {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
   min-height: 28px;
   padding: 0 12px;
   border: 1px solid var(--ui-color-border);
@@ -81,24 +80,6 @@
   color: var(--ui-color-brand-text);
   border-color: var(--ui-color-brand-text);
   background: color-mix(in srgb, var(--ui-color-brand-text) 8%, transparent);
-}
-
-.tagFilterPendingHint {
-  display: inline-block;
-  width: 5px;
-  height: 5px;
-  border-radius: 999px;
-  background: currentColor;
-  opacity: 0;
-  transform: scale(0.68);
-  transition: opacity 120ms ease, transform 120ms ease;
-}
-
-.tagFilterPendingHint[data-link-pending="true"],
-.tagFilter[data-pending="true"] .tagFilterPendingHint {
-  opacity: 0.72;
-  transform: scale(1);
-  animation: tag-filter-pulse 820ms ease-in-out infinite;
 }
 
 .timeline {
@@ -551,17 +532,6 @@
   }
 }
 
-@keyframes tag-filter-pulse {
-  0%,
-  100% {
-    opacity: 0.38;
-  }
-
-  50% {
-    opacity: 0.86;
-  }
-}
-
 @keyframes detail-enter {
   from {
     opacity: 0;
@@ -698,6 +668,10 @@
 
   .detailTitle {
     font-size: 2.5rem;
+  }
+
+  .detailHeader {
+    margin-bottom: 32px;
   }
 
   .floatingFeedToggle {

--- a/src/components/blog/blog-list.tsx
+++ b/src/components/blog/blog-list.tsx
@@ -35,15 +35,15 @@ export function BlogList({ posts }: { posts: PostMeta[] }) {
         pointerEvents: 'none',
       }} />
 
-      <section className="container" style={{ paddingTop: 120, paddingBottom: 48, position: 'relative', zIndex: 2 }}>
+      <section className="container" style={{ paddingTop: 'clamp(72px, 12vw, 120px)', paddingBottom: 48, position: 'relative', zIndex: 2 }}>
         <div className="eyebrow" style={{ marginBottom: 20, display: 'inline-flex', alignItems: 'center', gap: 10 }}>
           <span style={{ width: 24, height: 1, background: 'currentColor' }} />
           {BLOG.eyebrow} · {posts.length} {BLOG.entriesLabel}
         </div>
-        <h1 style={{ fontSize: '4rem', fontWeight: 700, lineHeight: 1.05, marginBottom: 24, letterSpacing: '-0.015em' }}>
+        <h1 style={{ fontSize: 'clamp(2.35rem, 6vw, 4rem)', fontWeight: 700, lineHeight: 1.05, marginBottom: 24, letterSpacing: 0 }}>
           {BLOG.heading}
         </h1>
-        <p style={{ fontSize: 17, color: 'var(--ui-color-text-muted)', maxWidth: 540, lineHeight: 1.7 }}>
+        <p style={{ fontSize: 'clamp(16px, 1.7vw, 17px)', color: 'var(--ui-color-text-muted)', maxWidth: 540, lineHeight: 1.7 }}>
           {BLOG.description}
         </p>
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 44 }}>

--- a/src/components/daily/daily-tag-filters.tsx
+++ b/src/components/daily/daily-tag-filters.tsx
@@ -1,17 +1,12 @@
 'use client';
 
-import Link, { useLinkStatus } from 'next/link';
+import Link from 'next/link';
 import { useState } from 'react';
 import styles from '##/app/daily/page.module.css';
 
 interface PendingTag {
   from: string | null;
   to: string | null;
-}
-
-function TagFilterPendingHint() {
-  const { pending } = useLinkStatus();
-  return <span aria-hidden="true" className={styles.tagFilterPendingHint} data-link-pending={pending} />;
 }
 
 function getTagFilterHref(baseHref: string, tag: string | null) {
@@ -34,7 +29,6 @@ export function DailyTagFilters({
 
   function renderFilter(tag: string | null, label: string) {
     const isActive = optimisticActiveTag === tag;
-    const isPending = hasActivePendingTag && pendingTag.to === tag;
 
     return (
       <Link
@@ -45,13 +39,11 @@ export function DailyTagFilters({
         className={styles.tagFilter}
         aria-current={isActive ? 'page' : undefined}
         data-active={isActive}
-        data-pending={isPending}
         onNavigate={() => {
           if (currentTag !== tag) setPendingTag({ from: currentTag, to: tag });
         }}
       >
         <span>{label}</span>
-        <TagFilterPendingHint />
       </Link>
     );
   }

--- a/src/components/home/hero.module.css
+++ b/src/components/home/hero.module.css
@@ -217,7 +217,7 @@
     min-height: calc(100dvh - 137px);
     min-height: calc(var(--visual-viewport-height, 100dvh) - 137px);
     flex-direction: column;
-    justify-content: flex-start;
+    justify-content: center;
     margin: 0 auto;
     padding: clamp(22px, 4dvh, 40px) clamp(28px, 8vw, 72px) clamp(32px, 6dvh, 56px);
     text-align: center;

--- a/test/daily-collapsible-feed.test.mjs
+++ b/test/daily-collapsible-feed.test.mjs
@@ -50,10 +50,11 @@ test('daily detail layout exposes desktop collapse and mobile drawer contracts',
   assert.match(experience, /navigationKey/);
   assert.match(experience, /resetKey=\{navigationKey\}/);
   assert.match(tagFilters, /'use client'/);
-  assert.match(tagFilters, /useLinkStatus/);
   assert.match(tagFilters, /prefetch=\{true\}/);
   assert.match(tagFilters, /optimisticActiveTag/);
-  assert.match(tagFilters, /data-pending/);
+  assert.doesNotMatch(tagFilters, /useLinkStatus/);
+  assert.doesNotMatch(tagFilters, /data-pending/);
+  assert.doesNotMatch(tagFilters, /TagFilterPendingHint/);
   assert.match(feedPane, /id\?: string/);
   assert.match(feedPane, /resetKey: string/);
   assert.match(feedPane, /pane\.scrollTop = 0/);
@@ -88,8 +89,8 @@ test('daily detail layout exposes desktop collapse and mobile drawer contracts',
   assert.match(css, /\.tagFilter\[data-active="true"\]\s*{[^}]*color:\s*var\(--ui-color-brand-text\)/);
   assert.match(css, /\.tagFilter\[data-active="true"\]\s*{[^}]*border-color:\s*var\(--ui-color-brand-text\)/);
   assert.match(css, /\.tagFilter\[data-active="true"\]\s*{[^}]*background:\s*color-mix\(in srgb,\s*var\(--ui-color-brand-text\)/);
-  assert.match(css, /\.tagFilterPendingHint\s*{/);
-  assert.match(css, /\.tagFilter\[data-pending="true"\]\s+\.tagFilterPendingHint/);
+  assert.doesNotMatch(css, /\.tagFilterPendingHint\s*{/);
+  assert.doesNotMatch(css, /\.tagFilter\[data-pending="true"\]\s+\.tagFilterPendingHint/);
   assert.match(navCss, /--button-ghost-background-hover:\s*transparent/);
   assert.match(css, /\.floatingFeedToggle\s*{[\s\S]*transition:[^;]*transform[^;]*opacity/);
   assert.match(css, /\.floatingFeedToggle:hover,[\s\S]*\.floatingFeedToggle:focus-visible\s*{[\s\S]*opacity:\s*0\.92/);


### PR DESCRIPTION
## Summary
- Align mobile blog hero spacing, title, and description scale with the daily page
- Center the mobile home hero profile block vertically
- Tighten daily detail header spacing and remove tag-filter pending dot UI
- Update daily layout contract test for the removed pending-dot behavior

## Verification
- pnpm test
- pnpm lint (passes with existing `<img>` warnings)